### PR TITLE
feat: query validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ go.work.sum
 # .vscode/
 *.out
 *.prof
+.hive-mind

--- a/engine_test.go
+++ b/engine_test.go
@@ -1,3 +1,24 @@
 package rule
 
-// Test file temporarily empty due to test package reorganization
+import (
+	"testing"
+)
+
+// TestQueryValidation tests the engine's query validation capabilities.
+func TestQueryValidation(t *testing.T) {
+	t.Run("BasicValidation", testBasicQueryValidation)
+	t.Run("PropertyValidation", testPropertyValidation)
+	t.Run("ParenthesesValidation", testParenthesesValidation)
+	t.Run("LogicalValidation", testLogicalValidation)
+	t.Run("EdgeCaseValidation", testEdgeCaseValidation)
+	t.Run("ValidComplexQueries", testValidComplexQueries)
+}
+
+// TestSemanticValidation tests the engine's semantic validation capabilities.
+func TestSemanticValidation(t *testing.T) {
+	t.Run("InOperatorValidation", testInOperatorValidation)
+	t.Run("StringOperatorValidation", testStringOperatorValidation)
+	t.Run("PresenceOperatorValidation", testPresenceOperatorValidation)
+	t.Run("EmptyQueryValidation", testEmptyQueryValidation)
+	t.Run("ComplexValidQueries", testComplexValidQueries)
+}

--- a/errors.go
+++ b/errors.go
@@ -24,4 +24,26 @@ var (
 	ErrParseError      = &EngineError{"PARSE_ERROR", "Failed to parse rule"}
 	ErrEvaluationError = &EngineError{"EVALUATION_ERROR", "Failed to evaluate rule"}
 	ErrRuleNotFound    = &EngineError{"RULE_NOT_FOUND", "Rule not found - use AddQuery to pre-compile rule"}
+
+	// ErrUnterminatedString indicates an unterminated string literal in the query.
+	ErrUnterminatedString = &EngineError{"UNTERMINATED_STRING", "Unterminated string literal"}
+	// ErrMissingOperator indicates missing operator between operands.
+	ErrMissingOperator = &EngineError{"MISSING_OPERATOR", "Missing operator between operands"}
+	// ErrInvalidSyntax indicates invalid query syntax.
+	ErrInvalidSyntax = &EngineError{"INVALID_SYNTAX", "Invalid query syntax"}
+
+	// ErrInvalidInOperand indicates IN operator used with non-array operand.
+	ErrInvalidInOperand = &EngineError{"INVALID_IN_OPERAND", "IN operator requires an array operand"}
+	ErrInvalidStringOp  = &EngineError{
+		"INVALID_STRING_OP",
+		"String operators (co/sw/ew) can only be used with string operands",
+	}
+	ErrInvalidPresenceOp = &EngineError{
+		"INVALID_PRESENCE_OP",
+		"Presence operator (pr) can only be used with identifiers or properties",
+	}
+	ErrEmptyQuery       = &EngineError{"EMPTY_QUERY", "Query cannot be empty"}
+	ErrEmptyParentheses = &EngineError{"EMPTY_PARENTHESES", "Empty parentheses are not allowed"}
+	ErrUnbalancedParens = &EngineError{"UNBALANCED_PARENTHESES", "Unbalanced parentheses"}
+	ErrTrailingTokens   = &EngineError{"TRAILING_TOKENS", "Unexpected tokens after complete expression"}
 )

--- a/errors_test.go
+++ b/errors_test.go
@@ -24,6 +24,16 @@ func TestErrorInterface(t *testing.T) {
 		{ErrParseError, "Failed to parse rule"},
 		{ErrEvaluationError, "Failed to evaluate rule"},
 		{ErrRuleNotFound, "Rule not found - use AddQuery to pre-compile rule"},
+		{ErrUnterminatedString, "Unterminated string literal"},
+		{ErrMissingOperator, "Missing operator between operands"},
+		{ErrInvalidSyntax, "Invalid query syntax"},
+		{ErrInvalidInOperand, "IN operator requires an array operand"},
+		{ErrInvalidStringOp, "String operators (co/sw/ew) can only be used with string operands"},
+		{ErrInvalidPresenceOp, "Presence operator (pr) can only be used with identifiers or properties"},
+		{ErrEmptyQuery, "Query cannot be empty"},
+		{ErrEmptyParentheses, "Empty parentheses are not allowed"},
+		{ErrUnbalancedParens, "Unbalanced parentheses"},
+		{ErrTrailingTokens, "Unexpected tokens after complete expression"},
 	}
 
 	for _, test := range errors {

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -231,7 +231,11 @@ func TestLexerReadString(t *testing.T) {
 	lexer := NewLexer(`"hello world"`)
 	// Start at opening quote, readString() should handle consuming it
 
-	result := lexer.readString()
+	result, err := lexer.readString()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
 	if result != "hello world" {
 		t.Errorf("Expected 'hello world', got '%s'", result)
 	}

--- a/query_validation_test.go
+++ b/query_validation_test.go
@@ -1,0 +1,368 @@
+package rule
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func testBasicQueryValidation(t *testing.T) {
+	engine := NewEngine()
+
+	testCases := []struct {
+		name        string
+		query       string
+		expectError bool
+		errorType   *EngineError
+	}{
+		{
+			name:        "Valid simple query",
+			query:       `x eq 10`,
+			expectError: false,
+		},
+		{
+			name:        "Valid complex query",
+			query:       `user.age gt 18 and status eq "active"`,
+			expectError: false,
+		},
+		{
+			name:        "Missing operator between operands",
+			query:       `something "else"`,
+			expectError: true,
+			errorType:   ErrMissingOperator,
+		},
+		{
+			name:        "Unterminated string literal",
+			query:       `name eq "unclosed`,
+			expectError: true,
+			errorType:   ErrUnterminatedString,
+		},
+		{
+			name:        "Missing right operand",
+			query:       `x eq`,
+			expectError: true,
+		},
+		{
+			name:        "Missing left operand",
+			query:       `eq "value"`,
+			expectError: true,
+		},
+		{
+			name:        "Multiple adjacent values",
+			query:       `x y z`,
+			expectError: true,
+			errorType:   ErrMissingOperator,
+		},
+		{
+			name:        "Number followed by string without operator",
+			query:       `123 "test"`,
+			expectError: true,
+			errorType:   ErrMissingOperator,
+		},
+	}
+
+	runTestCases(t, engine, testCases)
+}
+
+func testPropertyValidation(t *testing.T) {
+	engine := NewEngine()
+
+	testCases := []struct {
+		name        string
+		query       string
+		expectError bool
+		errorType   *EngineError
+	}{
+		{
+			name:        "Trailing dot in property",
+			query:       `something.else. in ["a"]`,
+			expectError: true,
+		},
+		{
+			name:        "Double dot in property",
+			query:       `something..else eq "test"`,
+			expectError: true,
+		},
+		{
+			name:        "Property ending with dot",
+			query:       `something. eq "test"`,
+			expectError: true,
+		},
+		{
+			name:        "Property starting with dot",
+			query:       `.something eq "test"`,
+			expectError: true,
+		},
+		{
+			name:        "Trailing dot with presence operator",
+			query:       `user.profile. pr`,
+			expectError: true,
+		},
+	}
+
+	runTestCases(t, engine, testCases)
+}
+
+func testParenthesesValidation(t *testing.T) {
+	engine := NewEngine()
+
+	testCases := []struct {
+		name        string
+		query       string
+		expectError bool
+		errorType   *EngineError
+	}{
+		{
+			name:        "Missing closing parenthesis",
+			query:       `(something eq "test"`,
+			expectError: true,
+		},
+		{
+			name:        "Extra closing parenthesis",
+			query:       `something eq "test")`,
+			expectError: true,
+			errorType:   ErrTrailingTokens,
+		},
+		{
+			name:        "Multiple missing closing parentheses",
+			query:       `((something eq "test")`,
+			expectError: true,
+		},
+		{
+			name:        "Multiple extra closing parentheses",
+			query:       `(something eq "test"))`,
+			expectError: true,
+			errorType:   ErrTrailingTokens,
+		},
+		{
+			name:        "Parentheses in wrong order",
+			query:       `)(something eq "test"(`,
+			expectError: true,
+		},
+		{
+			name:        "Empty parentheses",
+			query:       `(())`,
+			expectError: true,
+			errorType:   ErrEmptyParentheses,
+		},
+	}
+
+	runTestCases(t, engine, testCases)
+}
+
+func testLogicalValidation(t *testing.T) {
+	engine := NewEngine()
+
+	testCases := []struct {
+		name        string
+		query       string
+		expectError bool
+		errorType   *EngineError
+	}{
+		{
+			name:        "Missing right operand after OR",
+			query:       `((something eq "12") or )`,
+			expectError: true,
+		},
+		{
+			name:        "Missing left operand before OR",
+			query:       `( or something eq "test")`,
+			expectError: true,
+		},
+		{
+			name:        "Missing right operand after AND",
+			query:       `something eq "test" and`,
+			expectError: true,
+		},
+		{
+			name:        "Missing left operand before AND",
+			query:       `and something eq "test"`,
+			expectError: true,
+		},
+		{
+			name:        "Double OR operator",
+			query:       `something eq "test" or or`,
+			expectError: true,
+		},
+		{
+			name:        "Double AND operator",
+			query:       `something and and "test"`,
+			expectError: true,
+		},
+		{
+			name:        "Incomplete and expression",
+			query:       `x eq "value" and`,
+			expectError: true,
+		},
+	}
+
+	runTestCases(t, engine, testCases)
+}
+
+func testEdgeCaseValidation(t *testing.T) {
+	engine := NewEngine()
+
+	testCases := []struct {
+		name        string
+		query       string
+		expectError bool
+		errorType   *EngineError
+	}{
+		{
+			name:        "Multiple missing closing in nested",
+			query:       `(((something eq "test"`,
+			expectError: true,
+		},
+		{
+			name:        "Multiple extra closing in nested",
+			query:       `something eq "test")))`,
+			expectError: true,
+			errorType:   ErrTrailingTokens,
+		},
+		{
+			name:        "Incomplete expression in nested parentheses",
+			query:       `((something eq "test") and)`,
+			expectError: true,
+		},
+		{
+			name:        "Empty nested parentheses",
+			query:       `(something eq "test" and ())`,
+			expectError: true,
+			errorType:   ErrEmptyParentheses,
+		},
+		{
+			name:        "Property dot + missing operand",
+			query:       `something. and (missing eq)`,
+			expectError: true,
+		},
+		{
+			name:        "Property double dot + missing paren",
+			query:       `(something..else eq "test" or`,
+			expectError: true,
+		},
+		{
+			name:        "Unterminated string + paren",
+			query:       `something eq "unclosed and )`,
+			expectError: true,
+			errorType:   ErrUnterminatedString,
+		},
+		{
+			name:        "Multiple validation issues",
+			query:       `(something in "string") or .`,
+			expectError: true,
+		},
+		{
+			name:        "Operator without operands",
+			query:       `eq`,
+			expectError: true,
+		},
+		{
+			name:        "Only operator",
+			query:       `and`,
+			expectError: true,
+		},
+		{
+			name:        "Nested empty expressions",
+			query:       `(()) and (())`,
+			expectError: true,
+			errorType:   ErrEmptyParentheses,
+		},
+		{
+			name:        "Array with missing closing",
+			query:       `field in [1, 2, 3`,
+			expectError: true,
+		},
+		{
+			name:        "Array with extra closing",
+			query:       `field in [1, 2, 3]]`,
+			expectError: true,
+			errorType:   ErrTrailingTokens,
+		},
+		{
+			name:        "Field with hyphen (tokenized as separate)",
+			query:       `field-name eq "test"`,
+			expectError: true,
+		},
+		{
+			name:        "Multiple operators without operands",
+			query:       `eq ne lt gt`,
+			expectError: true,
+		},
+		{
+			name:        "Operator sandwich",
+			query:       `field eq ne "test"`,
+			expectError: true,
+		},
+		{
+			name:        "Excessive whitespace with missing operand",
+			query:       `field    eq     `,
+			expectError: true,
+		},
+		{
+			name:        "Tabs and spaces mixing with errors",
+			query:       "\tfield\t\teq\t\t",
+			expectError: true,
+		},
+	}
+
+	runTestCases(t, engine, testCases)
+}
+
+func testValidComplexQueries(t *testing.T) {
+	engine := NewEngine()
+
+	testCases := []struct {
+		name        string
+		query       string
+		expectError bool
+		errorType   *EngineError
+	}{
+		{
+			name:        "Complex nested valid expression",
+			query:       `((user.age gt 18 and user.active eq true) or (user.premium eq true)) and user.email pr`,
+			expectError: false,
+		},
+		{
+			name:        "Deep nesting valid",
+			query:       `(((field eq "value")))`,
+			expectError: false,
+		},
+		{
+			name:        "Complex array operations",
+			query:       `user.roles in ["admin", "user", "guest"] and user.permissions in []`,
+			expectError: false,
+		},
+		{
+			name:        "Mixed operators valid",
+			query:       `name co "John" and age gt 18 and active eq true and email pr`,
+			expectError: false,
+		},
+	}
+
+	runTestCases(t, engine, testCases)
+}
+
+func runTestCases(t *testing.T, engine *Engine, testCases []struct {
+	name        string
+	query       string
+	expectError bool
+	errorType   *EngineError
+},
+) {
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := engine.AddQuery(tc.query)
+			if !tc.expectError {
+				require.NoError(t, err, "query=%q", tc.query)
+				return
+			}
+
+			require.Error(t, err, "Expected error for query=%q", tc.query)
+
+			// Check for specific error type if provided
+			if tc.errorType != nil {
+				require.Contains(t, err.Error(), tc.errorType.Message, "query=%q", tc.query)
+			}
+		})
+	}
+}

--- a/semantic_validation_test.go
+++ b/semantic_validation_test.go
@@ -1,0 +1,230 @@
+package rule
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func testInOperatorValidation(t *testing.T) {
+	engine := NewEngine()
+
+	testCases := []struct {
+		name        string
+		query       string
+		expectError bool
+		errorType   *EngineError
+	}{
+		{
+			name:        "IN with string literal",
+			query:       `field in "string"`,
+			expectError: true,
+			errorType:   ErrInvalidInOperand,
+		},
+		{
+			name:        "IN with number literal",
+			query:       `field in 123`,
+			expectError: true,
+			errorType:   ErrInvalidInOperand,
+		},
+		{
+			name:        "IN with boolean literal",
+			query:       `field in true`,
+			expectError: true,
+			errorType:   ErrInvalidInOperand,
+		},
+		{
+			name:        "IN with array (valid)",
+			query:       `field in [1,2,3]`,
+			expectError: false,
+		},
+		{
+			name:        "IN with identifier (valid - runtime check)",
+			query:       `field in otherField`,
+			expectError: false,
+		},
+		{
+			name:        "IN with property (valid - runtime check)",
+			query:       `field in user.roles`,
+			expectError: false,
+		},
+		{
+			name:        "IN with empty array (valid)",
+			query:       `field in []`,
+			expectError: false,
+		},
+	}
+
+	runSemanticTestCases(t, engine, testCases)
+}
+
+func testStringOperatorValidation(t *testing.T) {
+	engine := NewEngine()
+
+	testCases := []struct {
+		name        string
+		query       string
+		expectError bool
+		errorType   *EngineError
+	}{
+		{
+			name:        "Contains with number left operand",
+			query:       `123 co "test"`,
+			expectError: true,
+			errorType:   ErrInvalidStringOp,
+		},
+		{
+			name:        "Contains with boolean left operand",
+			query:       `true co "test"`,
+			expectError: true,
+			errorType:   ErrInvalidStringOp,
+		},
+		{
+			name:        "Starts with number left operand",
+			query:       `123 sw "1"`,
+			expectError: true,
+			errorType:   ErrInvalidStringOp,
+		},
+		{
+			name:        "Ends with number right operand",
+			query:       `"test" ew 123`,
+			expectError: true,
+			errorType:   ErrInvalidStringOp,
+		},
+		{
+			name:        "Contains with string operands (valid)",
+			query:       `"hello" co "ell"`,
+			expectError: false,
+		},
+		{
+			name:        "Contains with identifier (valid - runtime check)",
+			query:       `name co "test"`,
+			expectError: false,
+		},
+	}
+
+	runSemanticTestCases(t, engine, testCases)
+}
+
+func testPresenceOperatorValidation(t *testing.T) {
+	engine := NewEngine()
+
+	testCases := []struct {
+		name        string
+		query       string
+		expectError bool
+		errorType   *EngineError
+	}{
+		{
+			name:        "Presence with string literal",
+			query:       `"string" pr`,
+			expectError: true,
+			errorType:   ErrInvalidPresenceOp,
+		},
+		{
+			name:        "Presence with number literal",
+			query:       `123 pr`,
+			expectError: true,
+			errorType:   ErrInvalidPresenceOp,
+		},
+		{
+			name:        "Presence with boolean literal",
+			query:       `true pr`,
+			expectError: true,
+			errorType:   ErrInvalidPresenceOp,
+		},
+		{
+			name:        "Presence with identifier (valid)",
+			query:       `field pr`,
+			expectError: false,
+		},
+		{
+			name:        "Presence with property (valid)",
+			query:       `user.email pr`,
+			expectError: false,
+		},
+	}
+
+	runSemanticTestCases(t, engine, testCases)
+}
+
+func testEmptyQueryValidation(t *testing.T) {
+	engine := NewEngine()
+
+	testCases := []struct {
+		name        string
+		query       string
+		expectError bool
+		errorType   *EngineError
+	}{
+		{
+			name:        "Empty query",
+			query:       ``,
+			expectError: true,
+			errorType:   ErrEmptyQuery,
+		},
+		{
+			name:        "Whitespace only query",
+			query:       `   `,
+			expectError: true,
+			errorType:   ErrEmptyQuery,
+		},
+		{
+			name:        "Tab and newline only",
+			query:       "\t\n  ",
+			expectError: true,
+			errorType:   ErrEmptyQuery,
+		},
+	}
+
+	runSemanticTestCases(t, engine, testCases)
+}
+
+func testComplexValidQueries(t *testing.T) {
+	engine := NewEngine()
+
+	testCases := []struct {
+		name        string
+		query       string
+		expectError bool
+		errorType   *EngineError
+	}{
+		{
+			name:        "Complex valid query with multiple operators",
+			query:       `user.age gt 18 and user.name co "John" and user.roles in ["admin", "user"]`,
+			expectError: false,
+		},
+		{
+			name:        "Nested parentheses with valid operators",
+			query:       `(user.active pr and user.age ge 21) or (user.premium eq true and user.trial_days in [7, 14, 30])`,
+			expectError: false,
+		},
+	}
+
+	runSemanticTestCases(t, engine, testCases)
+}
+
+func runSemanticTestCases(t *testing.T, engine *Engine, testCases []struct {
+	name        string
+	query       string
+	expectError bool
+	errorType   *EngineError
+},
+) {
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := engine.AddQuery(tc.query)
+			if !tc.expectError {
+				require.NoError(t, err, "query=%q", tc.query)
+				return
+			}
+
+			require.Error(t, err, "Expected error for query=%q", tc.query)
+
+			// Check for specific error type if provided
+			if tc.errorType != nil {
+				require.Contains(t, err.Error(), tc.errorType.Message, "query=%q", tc.query)
+			}
+		})
+	}
+}

--- a/validator.go
+++ b/validator.go
@@ -1,0 +1,132 @@
+package rule
+
+import "errors"
+
+// ValidateAST performs semantic validation on the parsed AST.
+func ValidateAST(node *ASTNode) error {
+	if node == nil {
+		return nil
+	}
+
+	switch node.Type {
+	case NodeBinaryOp:
+		if err := validateBinaryOperation(node); err != nil {
+			return err
+		}
+
+		// Recursively validate children
+		if err := ValidateAST(node.Left); err != nil {
+			return err
+		}
+
+		if err := ValidateAST(node.Right); err != nil {
+			return err
+		}
+
+	case NodeUnaryOp:
+		if err := validateUnaryOperation(node); err != nil {
+			return err
+		}
+
+		// Recursively validate the operand
+		if err := ValidateAST(node.Left); err != nil {
+			return err
+		}
+
+	case NodeLiteral, NodeIdentifier, NodeProperty, NodeArray:
+		// These are terminal nodes, no further validation needed
+		return nil
+	}
+
+	return nil
+}
+
+func validateBinaryOperation(node *ASTNode) error {
+	if node.Left == nil || node.Right == nil {
+		return errors.New("binary operation missing operands")
+	}
+
+	switch node.Operator {
+	case IN:
+		return validateInOperation(node)
+	case CO, SW, EW:
+		return validateStringOperation(node)
+	case EOF, IDENTIFIER, STRING, NUMBER, BOOLEAN, ARRAY_START, ARRAY_END,
+		PAREN_OPEN, PAREN_CLOSE, DOT, COMMA, EQ, NE, LT, GT, LE, GE, PR,
+		DQ, DN, BE, BQ, AF, AQ, AND, OR, NOT, EQUALS, NOT_EQUALS:
+		// Other operators don't need special validation
+		return nil
+	}
+
+	return nil
+}
+
+func validateUnaryOperation(node *ASTNode) error {
+	if node.Left == nil {
+		return errors.New("unary operation missing operand")
+	}
+
+	switch node.Operator {
+	case PR:
+		return validatePresenceOperation(node)
+	case EOF, IDENTIFIER, STRING, NUMBER, BOOLEAN, ARRAY_START, ARRAY_END,
+		PAREN_OPEN, PAREN_CLOSE, DOT, COMMA, EQ, NE, LT, GT, LE, GE,
+		CO, SW, EW, IN, DQ, DN, BE, BQ, AF, AQ, AND, OR, NOT, EQUALS, NOT_EQUALS:
+		// Other operators don't apply to unary operations
+		return nil
+	}
+
+	return nil
+}
+
+func validateInOperation(node *ASTNode) error {
+	// The right operand of IN must be an array
+	if node.Right.Type != NodeArray {
+		// Check if it's a literal that's not an array
+		switch node.Right.Type {
+		case NodeLiteral:
+			if node.Right.Value.Type != ValueArray {
+				return ErrInvalidInOperand
+			}
+		case NodeIdentifier, NodeProperty:
+			// Allow identifiers/properties as they might evaluate to arrays at runtime
+			return nil
+		case NodeBinaryOp, NodeUnaryOp, NodeArray:
+			return ErrInvalidInOperand
+		}
+	}
+
+	return nil
+}
+
+func validateStringOperation(node *ASTNode) error {
+	// String operations (co, sw, ew) should typically work on strings
+	// But we'll allow identifiers/properties as they might be strings at runtime
+	left := node.Left
+	right := node.Right
+
+	// Check if we're trying to use string operators on obviously non-string literals
+	if left.Type == NodeLiteral {
+		if left.Value.Type != ValueString {
+			return ErrInvalidStringOp
+		}
+	}
+
+	if right.Type == NodeLiteral {
+		if right.Value.Type != ValueString {
+			return ErrInvalidStringOp
+		}
+	}
+
+	return nil
+}
+
+func validatePresenceOperation(node *ASTNode) error {
+	// Presence operator should only work on identifiers or properties
+	operand := node.Left
+	if operand.Type != NodeIdentifier && operand.Type != NodeProperty {
+		return ErrInvalidPresenceOp
+	}
+
+	return nil
+}

--- a/validator_test.go
+++ b/validator_test.go
@@ -1,0 +1,227 @@
+package rule
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateAST(t *testing.T) {
+	t.Run("NilAST", testNilASTValidation)
+	t.Run("ValidQueries", testValidASTQueries)
+	t.Run("InvalidQueries", testInvalidASTQueries)
+}
+
+func testNilASTValidation(t *testing.T) {
+	err := ValidateAST(nil)
+	require.NoError(t, err, "ValidateAST(nil) should return nil")
+}
+
+func testValidASTQueries(t *testing.T) {
+	tests := []string{
+		`field eq "value"`,
+		`field in [1, 2, 3]`,
+		`"hello" co "ell"`,
+		`field pr`,
+	}
+
+	for _, query := range tests {
+		t.Run(query, func(t *testing.T) {
+			ast, err := ParseRule(query)
+			require.NoError(t, err, "query=%q", query)
+
+			validationErr := ValidateAST(ast)
+			require.NoError(t, validationErr, "query=%q", query)
+		})
+	}
+}
+
+func testInvalidASTQueries(t *testing.T) {
+	tests := []struct {
+		query     string
+		errorType *EngineError
+	}{
+		{`field in "string"`, ErrInvalidInOperand},
+		{`123 co "test"`, ErrInvalidStringOp},
+		{`"string" pr`, ErrInvalidPresenceOp},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.query, func(t *testing.T) {
+			_, parseErr := ParseRule(tt.query)
+			if parseErr == nil {
+				t.Errorf("Expected parsing error for query '%s', but got none", tt.query)
+				return
+			}
+
+			if !strings.Contains(parseErr.Error(), tt.errorType.Message) {
+				t.Errorf("Expected error containing '%s', got '%s'", tt.errorType.Message, parseErr.Error())
+			}
+		})
+	}
+}
+
+func TestValidateInOperation(t *testing.T) {
+	tests := []struct {
+		name        string
+		rightType   NodeType
+		rightValue  Value
+		expectError bool
+	}{
+		{
+			name:        "Array node (valid)",
+			rightType:   NodeArray,
+			expectError: false,
+		},
+		{
+			name:        "Identifier (valid - runtime check)",
+			rightType:   NodeIdentifier,
+			expectError: false,
+		},
+		{
+			name:        "Property (valid - runtime check)",
+			rightType:   NodeProperty,
+			expectError: false,
+		},
+		{
+			name:        "String literal (invalid)",
+			rightType:   NodeLiteral,
+			rightValue:  Value{Type: ValueString, StrValue: "test"},
+			expectError: true,
+		},
+		{
+			name:        "Number literal (invalid)",
+			rightType:   NodeLiteral,
+			rightValue:  Value{Type: ValueNumber, NumValue: 123},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := &ASTNode{
+				Type:     NodeBinaryOp,
+				Operator: IN,
+				Left:     &ASTNode{Type: NodeIdentifier},
+				Right: &ASTNode{
+					Type:  tt.rightType,
+					Value: tt.rightValue,
+				},
+			}
+
+			err := validateInOperation(node)
+			if tt.expectError && err == nil {
+				t.Error("Expected error but got none")
+			} else if !tt.expectError && err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateStringOperation(t *testing.T) {
+	tests := []struct {
+		name        string
+		leftValue   Value
+		rightValue  Value
+		expectError bool
+	}{
+		{
+			name:        "Both strings (valid)",
+			leftValue:   Value{Type: ValueString, StrValue: "hello"},
+			rightValue:  Value{Type: ValueString, StrValue: "ell"},
+			expectError: false,
+		},
+		{
+			name:        "Left number (invalid)",
+			leftValue:   Value{Type: ValueNumber, NumValue: 123},
+			rightValue:  Value{Type: ValueString, StrValue: "test"},
+			expectError: true,
+		},
+		{
+			name:        "Right number (invalid)",
+			leftValue:   Value{Type: ValueString, StrValue: "test"},
+			rightValue:  Value{Type: ValueNumber, NumValue: 123},
+			expectError: true,
+		},
+		{
+			name:        "Both numbers (invalid)",
+			leftValue:   Value{Type: ValueNumber, NumValue: 123},
+			rightValue:  Value{Type: ValueNumber, NumValue: 456},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := &ASTNode{
+				Type:     NodeBinaryOp,
+				Operator: CO, // Using contains operator
+				Left: &ASTNode{
+					Type:  NodeLiteral,
+					Value: tt.leftValue,
+				},
+				Right: &ASTNode{
+					Type:  NodeLiteral,
+					Value: tt.rightValue,
+				},
+			}
+
+			err := validateStringOperation(node)
+			if tt.expectError && err == nil {
+				t.Error("Expected error but got none")
+			} else if !tt.expectError && err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidatePresenceOperation(t *testing.T) {
+	tests := []struct {
+		name        string
+		operandType NodeType
+		expectError bool
+	}{
+		{
+			name:        "Identifier (valid)",
+			operandType: NodeIdentifier,
+			expectError: false,
+		},
+		{
+			name:        "Property (valid)",
+			operandType: NodeProperty,
+			expectError: false,
+		},
+		{
+			name:        "Literal (invalid)",
+			operandType: NodeLiteral,
+			expectError: true,
+		},
+		{
+			name:        "Array (invalid)",
+			operandType: NodeArray,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := &ASTNode{
+				Type:     NodeUnaryOp,
+				Operator: PR,
+				Left: &ASTNode{
+					Type: tt.operandType,
+				},
+			}
+
+			err := validatePresenceOperation(node)
+			if tt.expectError && err == nil {
+				t.Error("Expected error but got none")
+			} else if !tt.expectError && err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- 
🚀 NSXBet/rule Contribution Guidelines

Thank you for contributing! This template helps ensure high-quality contributions.
Please fill out the sections below and remove any that don't apply.

📋 REQUIREMENTS CHECKLIST (check before submitting):
- [ ] Tests pass (`make test`)
- [ ] Linter passes 100% clean (`make lint`) 
- [ ] Fuzz tests pass (`make fuzz`) for edge case validation
- [ ] Zero allocations maintained in hot paths (if touching core evaluation)
- [ ] Benchmarks included for performance changes
- [ ] Documentation updated if adding features

🔧 DEVELOPMENT COMMANDS:
- `make test` - Run all tests
- `make lint` - Run linter (must be 100% clean)
- `make bench` - Run benchmarks
- `make fuzz` - Run fuzz tests for edge case detection
- `make format` - Format code

⚡ PERFORMANCE REQUIREMENTS:
- Core evaluation must remain under 100ns
- Zero allocations during rule evaluation (0 allocs/op)
- Thread-safe for concurrent usage

📚 CONTRIBUTION TYPES:
- 🐛 Bug fixes: Include test case reproducing the issue
- ⚡ Performance: Include before/after benchmarks
- 🔧 Features: Include tests, benchmarks, and documentation
- 📖 Docs: Ensure accuracy and clarity

🧪 TESTING:
- Add tests for new features
- Include edge cases and error scenarios
- Property-to-property comparisons should have comprehensive coverage
- DateTime operations should include timezone edge cases
- Run fuzz tests (`make fuzz`) for comprehensive edge case detection

📖 DOCUMENTATION:
- Update README if adding features
- Include code examples for new operators
- Update compatibility section if changing behavior
- Follow existing documentation style

🔒 SECURITY:
- Never commit secrets or keys
- Follow defensive programming practices
- Handle edge cases gracefully (don't panic)

For detailed guidelines, see the Contributing section in README.md
-->

## 📝 Summary

<!-- Add here a brief description of what this PR does.--->

This PR adds rule validation for a myriad of cases:

Syntactic Error Detection:
- something "else" → "Missing operator between operands"
- name eq "unclosed → "Unterminated string literal"
- x eq → "unexpected token EOF at position 2"
- "" (empty) → "Query cannot be empty"

Semantic Error Detection:
- field in "string" → "IN operator requires an array operand"
- 123 co "test" → "String operators (co/sw/ew) can only be used with string operands"
- "string" pr → "Presence operator (pr) can only be used with identifiers or properties"

## ⚡ Performance Impact

<!-- For performance-related changes, include benchmarks -->

- [x] No performance impact
- [ ] Performance improved (include benchmarks)
- [ ] Performance regression (justify why acceptable)

## ✅ Checklist

- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Tests added for new functionality
- [x] README updated (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved error detection and messaging for invalid query syntax, missing operators, and semantic errors in queries.
  * Enhanced validation to ensure correct usage of operators and operands in queries.
  * Added semantic validation for query expressions to catch operand type mismatches, empty queries, empty parentheses, unbalanced parentheses, and trailing tokens.
* **Bug Fixes**
  * Queries with missing operators, unterminated strings, or invalid operand types are now properly flagged with descriptive errors.
  * Lexer now detects and reports unterminated string literals during tokenization.
  * Parser detects empty parentheses, trailing tokens, empty queries, and lexical errors with appropriate errors.
* **Tests**
  * Added comprehensive tests for query parsing, semantic validation, lexer error handling, and error message correctness.
* **Chores**
  * Updated `.gitignore` to exclude `.hive-mind` files from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->